### PR TITLE
Escape input/output path file separators

### DIFF
--- a/interpolate.sh
+++ b/interpolate.sh
@@ -134,7 +134,7 @@ if [ -n "$file_path_regex" ]; then
 fi
 
 for input_file_path in $input_file_paths; do
-	output_file_path="$(echo "$input_file_path" | sed -e "s/$input_path/$output_path/")"
+	output_file_path="$(echo "$input_file_path" | sed -e "s/$(escape_forward_slash $input_path)/$(escape_forward_slash $output_path)/")"
 	verbose_execute echo "Attempting to interpolate given variables in input file path: $input_file_path"
 
 	verbose_execute echo "Copying input file path ($input_file_path) contents into temporary file path: $temp_file_path"


### PR DESCRIPTION
This PR escapes file separators inside 'sed' command, which fixes the issue with incorrect `output_file_path` being constructed when either `input_path` or `output_path` has file separators. For more info, see this [issue](https://github.com/Dovias/interpolate.sh/issues/1)